### PR TITLE
fix: auto-initialize audio stream

### DIFF
--- a/libs/react-client/src/useChatSession.ts
+++ b/libs/react-client/src/useChatSession.ts
@@ -219,8 +219,8 @@ const useChatSession = () => {
         setAudioConnection(state);
       });
 
-      socket.on('audio_chunk', (chunk: OutputAudioChunk) => {
-        wavStreamPlayer.add16BitPCM(chunk.data, chunk.track);
+      socket.on('audio_chunk', async (chunk: OutputAudioChunk) => {
+        await wavStreamPlayer.add16BitPCM(chunk.data, chunk.track);
         setIsAiSpeaking(true);
       });
 

--- a/libs/react-client/src/wavtools/wav_stream_player.js
+++ b/libs/react-client/src/wavtools/wav_stream_player.js
@@ -1,3 +1,4 @@
+/* global AudioContext AudioWorkletNode crypto setTimeout globalThis console */
 import { AudioAnalysis } from './analysis/audio_analysis.js';
 import { StreamProcessorSrc } from './worklets/stream_processor.js';
 
@@ -102,11 +103,14 @@ export class WavStreamPlayer {
    * @param {string} [trackId]
    * @returns {Int16Array}
    */
-  add16BitPCM(arrayBuffer, trackId = 'default') {
+  async add16BitPCM(arrayBuffer, trackId = 'default') {
     if (typeof trackId !== 'string') {
       throw new Error(`trackId must be a string`);
     } else if (this.interruptedTrackIds[trackId]) {
       return;
+    }
+    if (!this.context) {
+      await this.connect();
     }
     if (!this.stream) {
       this._start();


### PR DESCRIPTION
## Summary
- ensure `WavStreamPlayer` auto-connects before playing
- await player writes when receiving audio chunks

## Testing
- `poetry run pytest`
- `pnpm test` *(fails: File does not exist: main.py)*

------
https://chatgpt.com/codex/tasks/task_e_6855515ca8b08320909fc76a52fce366