### PR TITLE
fix: auto-initialize audio stream

### DIFF
--- a/libs/react-client/src/useChatSession.ts
+++ b/libs/react-client/src/useChatSession.ts
@@ -219,8 +219,8 @@ const useChatSession = () => {
         setAudioConnection(state);
       });
 
-      socket.on('audio_chunk', (chunk: OutputAudioChunk) => {
-        wavStreamPlayer.add16BitPCM(chunk.data, chunk.track);
+      socket.on('audio_chunk', async (chunk: OutputAudioChunk) => {
+        await wavStreamPlayer.add16BitPCM(chunk.data, chunk.track);
         setIsAiSpeaking(true);
       });
 

--- a/libs/react-client/src/wavtools/wav_stream_player.js
+++ b/libs/react-client/src/wavtools/wav_stream_player.js
@@ -1,3 +1,4 @@
+/* global AudioContext AudioWorkletNode crypto setTimeout globalThis console */
 import { AudioAnalysis } from './analysis/audio_analysis.js';
 import { StreamProcessorSrc } from './worklets/stream_processor.js';
 
@@ -102,11 +103,14 @@ export class WavStreamPlayer {
    * @param {string} [trackId]
    * @returns {Int16Array}
    */
-  add16BitPCM(arrayBuffer, trackId = 'default') {
+  async add16BitPCM(arrayBuffer, trackId = 'default') {
     if (typeof trackId !== 'string') {
       throw new Error(`trackId must be a string`);
     } else if (this.interruptedTrackIds[trackId]) {
       return;
+    }
+    if (!this.context) {
+      await this.connect();
     }
     if (!this.stream) {
       this._start();


### PR DESCRIPTION
This pull request introduces changes to improve the handling of audio streaming in the `useChatSession` hook and the `WavStreamPlayer` class. The key updates include making the `add16BitPCM` method asynchronous to ensure proper initialization of audio resources and updating the corresponding socket event handler to handle the asynchronous behavior.

### Updates to audio streaming:

* [`libs/react-client/src/useChatSession.ts`](diffhunk://#diff-48ca74cb570a1d75a2b73f03b1406e847ade49e22decf2bef43fd975348f647cL222-R223): Updated the `audio_chunk` socket event handler to use `await` when calling `wavStreamPlayer.add16BitPCM`, ensuring asynchronous behavior is properly handled.
* [`libs/react-client/src/wavtools/wav_stream_player.js`](diffhunk://#diff-9b9313255897126d0d76440418d657fccc3115ed3e8b44e1437485bfe56120c3L105-R114): Made the `add16BitPCM` method asynchronous to ensure that the audio context is connected before processing audio chunks. Added a check to initialize the audio context with `await this.connect()` if it is not already set.

### Codebase maintenance:

* [`libs/react-client/src/wavtools/wav_stream_player.js`](diffhunk://#diff-9b9313255897126d0d76440418d657fccc3115ed3e8b44e1437485bfe56120c3R1): Added a global comment for better clarity on global variables used in the file.